### PR TITLE
Add StudentCore package for iOS student app

### DIFF
--- a/ios/StudentCore/.gitignore
+++ b/ios/StudentCore/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ios/StudentCore/Package.swift
+++ b/ios/StudentCore/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "StudentCore",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v10_15)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "StudentCore",
+            targets: ["StudentCore"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "StudentCore"
+        ),
+        .testTarget(
+            name: "StudentCoreTests",
+            dependencies: ["StudentCore"]
+        ),
+    ]
+)

--- a/ios/StudentCore/Sources/StudentCore/API.swift
+++ b/ios/StudentCore/Sources/StudentCore/API.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public protocol APIClient {
+    func fetchSession() async throws -> PracticeSession
+}
+
+public struct PracticeSession: Codable, Equatable {
+    public let id: String
+    public let questions: [Question]
+
+    public init(id: String, questions: [Question]) {
+        self.id = id
+        self.questions = questions
+    }
+}
+
+public final class PracticeService {
+    private let client: APIClient
+
+    public init(client: APIClient) {
+        self.client = client
+    }
+
+    public func fetchSession() async throws -> PracticeSession {
+        try await client.fetchSession()
+    }
+}
+
+public final class MockAPIClient: APIClient {
+    public var fetchSessionCalled = false
+
+    public init() {}
+
+    public func fetchSession() async throws -> PracticeSession {
+        fetchSessionCalled = true
+        return PracticeSession(id: "S1", questions: [])
+    }
+}

--- a/ios/StudentCore/Sources/StudentCore/Models.swift
+++ b/ios/StudentCore/Sources/StudentCore/Models.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct Question: Codable, Equatable {
+    public let id: String
+    public let questionType: String
+    public let stem: String
+    public let options: [QuestionOption]?
+    public let answerKey: AnswerKey
+
+    public init(id: String, questionType: String, stem: String, options: [QuestionOption]?, answerKey: AnswerKey) {
+        self.id = id
+        self.questionType = questionType
+        self.stem = stem
+        self.options = options
+        self.answerKey = answerKey
+    }
+}
+
+public struct QuestionOption: Codable, Equatable {
+    public let label: String
+    public let content: String
+
+    public init(label: String, content: String) {
+        self.label = label
+        self.content = content
+    }
+}
+
+public struct AnswerKey: Codable, Equatable {
+    public let correctString: String?
+    public let correctNumber: Double?
+
+    public init(correct: String) {
+        correctString = correct
+        correctNumber = nil
+    }
+
+    public init(correct: Double) {
+        correctNumber = correct
+        correctString = nil
+    }
+
+    enum CodingKeys: String, CodingKey { case correct }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let s = try? container.decode(String.self, forKey: .correct) {
+            correctString = s
+            correctNumber = nil
+        } else if let n = try? container.decode(Double.self, forKey: .correct) {
+            correctNumber = n
+            correctString = nil
+        } else {
+            correctString = nil
+            correctNumber = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let s = correctString { try container.encode(s, forKey: .correct) }
+        if let n = correctNumber { try container.encode(n, forKey: .correct) }
+    }
+}

--- a/ios/StudentCore/Sources/StudentCore/QuestionFeedViewModel.swift
+++ b/ios/StudentCore/Sources/StudentCore/QuestionFeedViewModel.swift
@@ -1,0 +1,15 @@
+import Combine
+
+public final class QuestionFeedViewModel: ObservableObject {
+    public let session: PracticeSession
+    @Published public private(set) var currentIndex: Int = 0
+
+    public init(session: PracticeSession) {
+        self.session = session
+    }
+
+    public func advance() {
+        guard currentIndex + 1 < session.questions.count else { return }
+        currentIndex += 1
+    }
+}

--- a/ios/StudentCore/Sources/StudentCore/StudentCore.swift
+++ b/ios/StudentCore/Sources/StudentCore/StudentCore.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/ios/StudentCore/Tests/StudentCoreTests/APITests.swift
+++ b/ios/StudentCore/Tests/StudentCoreTests/APITests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import StudentCore
+
+final class APITests: XCTestCase {
+    func testFetchSessionUsesClient() async throws {
+        let client = MockAPIClient()
+        let service = PracticeService(client: client)
+        _ = try await service.fetchSession()
+        XCTAssertEqual(client.fetchSessionCalled, true)
+    }
+}

--- a/ios/StudentCore/Tests/StudentCoreTests/ModelsTests.swift
+++ b/ios/StudentCore/Tests/StudentCoreTests/ModelsTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import StudentCore
+
+final class ModelsTests: XCTestCase {
+    func testQuestionDecodeMCQ() throws {
+        let json = #"{"id":"Q1","questionType":"mcq","stem":"2+2?","options":[{"label":"A","content":"3"},{"label":"B","content":"4"}],"answerKey":{"correct":"B"}}"#
+        let data = json.data(using: .utf8)!
+        let q = try JSONDecoder().decode(Question.self, from: data)
+        XCTAssertEqual(q.options?.count, 2)
+        XCTAssertEqual(q.answerKey.correctString, "B")
+    }
+}

--- a/ios/StudentCore/Tests/StudentCoreTests/QuestionFeedViewModelTests.swift
+++ b/ios/StudentCore/Tests/StudentCoreTests/QuestionFeedViewModelTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import StudentCore
+
+final class QuestionFeedViewModelTests: XCTestCase {
+    func testAdvanceMovesIndex() async throws {
+        let session = PracticeSession(id: "S1", questions: [
+            Question(id: "Q1", questionType: "mcq", stem: "A?", options: nil, answerKey: AnswerKey(correct: "A")),
+            Question(id: "Q2", questionType: "mcq", stem: "B?", options: nil, answerKey: AnswerKey(correct: "B"))
+        ])
+        let vm = QuestionFeedViewModel(session: session)
+        XCTAssertEqual(vm.currentIndex, 0)
+        vm.advance()
+        XCTAssertEqual(vm.currentIndex, 1)
+    }
+}


### PR DESCRIPTION
Adds the StudentCore Swift package with models, API abstraction, and the question feed view model. Includes XCTest coverage for decoding, API delegation, and index advancement. Tests: swift test.